### PR TITLE
Bump Yams

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_11.2.1.app
+  DEVELOPER_DIR: /Applications/Xcode_12.4.app
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Xcode list
-      run: ls /Applications
+      run: ls /Applications | grep 'Xcode'
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_11.2.1.app
     - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_12.4.app
 
 jobs:
-  build:
+  test:
 
     runs-on: macos-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push]
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_11.2.1.app
+
 jobs:
   build:
 
@@ -11,7 +14,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: Xcode list
       run: ls /Applications | grep 'Xcode'
-    - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_11.2.1.app
     - name: Test
       run: make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Xcode list
       run: ls /Applications
     - name: Select Xcode

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>


### PR DESCRIPTION
## Overview

SwiftLint 0.43.1 が Yams 4.0.2 以上に依存していて、合わせないと 1 つのパッケージで BuildTools を管理できないため更新する。

```
Dependencies could not be resolved because root depends on 'SwiftLint' 0.43.1 and root depends on 'SpellChecker' 0.0.3.
'SpellChecker' is incompatible with 'SwiftLint' because 'SpellChecker' depends on 'Yams' 2.0.0..<3.0.0 and 'SwiftLint' 0.43.1 depends on 'Yams' 4.0.2..<5.0.0.
```

## References

- https://github.com/realm/SwiftLint/blob/0.43.1/Package.swift#L20