### PR TITLE
Bump Yams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .executable(name: "SpellChecker", targets: ["SpellChecker"])
     ],
     dependencies: [
-        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0")
+        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.2")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Overview

SwiftLint 0.43.1 が Yams 4.0.2 以上に依存していて、合わせないと 1 つのパッケージで BuildTools を管理できないため更新する。

```
Dependencies could not be resolved because root depends on 'SwiftLint' 0.43.1 and root depends on 'SpellChecker' 0.0.3.
'SpellChecker' is incompatible with 'SwiftLint' because 'SpellChecker' depends on 'Yams' 2.0.0..<3.0.0 and 'SwiftLint' 0.43.1 depends on 'Yams' 4.0.2..<5.0.0.
```

## References

- https://github.com/realm/SwiftLint/blob/0.43.1/Package.swift#L20